### PR TITLE
Re-implemented the resolution spin-boxes in the confocal interface.

### DIFF
--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -350,16 +350,27 @@ class ConfocalGui(GUIBase):
         self._mw.z_SliderWidget.sliderMoved.connect(self.update_from_slider_z)
 
         # Take the default values from logic:
-        self._mw.xy_res_InputWidget.setValue(self._scanning_logic.xy_resolution)
+        self._mw.x_res_InputWidget.setValue(self._scanning_logic.xy_resolution)
+        self._mw.y_res_InputWidget.setValue(self._scanning_logic.xy_resolution)
         self._mw.z_res_InputWidget.setValue(self._scanning_logic.z_resolution)
+        self._mw.x_res_length_InputWidget.setValue(
+            (self._scanning_logic.image_x_range[1] - self._scanning_logic.image_x_range[0]) / self._scanning_logic.xy_resolution)
+        self._mw.y_res_length_InputWidget.setValue(
+            (self._scanning_logic.image_y_range[1] - self._scanning_logic.image_y_range[0]) / self._scanning_logic.xy_resolution)
+        self._mw.z_res_length_InputWidget.setValue(
+            (self._scanning_logic.image_z_range[1] - self._scanning_logic.image_z_range[0]) / self._scanning_logic.z_resolution)
 
         # Update the inputed/displayed numbers if the cursor has left the field:
         self._mw.x_current_InputWidget.editingFinished.connect(self.update_from_input_x)
         self._mw.y_current_InputWidget.editingFinished.connect(self.update_from_input_y)
         self._mw.z_current_InputWidget.editingFinished.connect(self.update_from_input_z)
 
-        self._mw.xy_res_InputWidget.editingFinished.connect(self.change_xy_resolution)
+        self._mw.x_res_InputWidget.editingFinished.connect(self.change_xy_resolution)
         self._mw.z_res_InputWidget.editingFinished.connect(self.change_z_resolution)
+        self._mw.x_res_length_InputWidget.editingFinished.connect(self.change_xy_resolution)
+        self._mw.z_res_length_InputWidget.editingFinished.connect(self.change_z_resolution)
+        self._mw.pixel_res_RadioButton.clicked.connect(self.update_res_input)
+        self._mw.length_res_RadioButton.clicked.connect(self.update_res_input)
 
         self._mw.x_min_InputWidget.editingFinished.connect(self.change_x_image_range)
         self._mw.x_max_InputWidget.editingFinished.connect(self.change_x_image_range)
@@ -770,8 +781,12 @@ class ConfocalGui(GUIBase):
         self._mw.z_min_InputWidget.setEnabled(False)
         self._mw.z_max_InputWidget.setEnabled(False)
 
-        self._mw.xy_res_InputWidget.setEnabled(False)
+        self._mw.pixel_res_RadioButton.setEnabled(False)
+        self._mw.length_res_RadioButton.setEnabled(False)
+        self._mw.x_res_InputWidget.setEnabled(False)
         self._mw.z_res_InputWidget.setEnabled(False)
+        self._mw.x_res_length_InputWidget.setEnabled(False)
+        self._mw.z_res_length_InputWidget.setEnabled(False)
 
         # Set the zoom button if it was pressed to unpressed and disable it
         self._mw.action_zoom.setChecked(False)
@@ -800,8 +815,9 @@ class ConfocalGui(GUIBase):
         self._mw.z_min_InputWidget.setEnabled(True)
         self._mw.z_max_InputWidget.setEnabled(True)
 
-        self._mw.xy_res_InputWidget.setEnabled(True)
-        self._mw.z_res_InputWidget.setEnabled(True)
+        self.update_res_input()
+        self._mw.pixel_res_RadioButton.setEnabled(True)
+        self._mw.length_res_RadioButton.setEnabled(True)
 
         self._mw.action_zoom.setEnabled(True)
 
@@ -1264,18 +1280,50 @@ class ConfocalGui(GUIBase):
     def change_xy_resolution(self):
         """ Update the xy resolution in the logic according to the GUI.
         """
-        self._scanning_logic.xy_resolution = self._mw.xy_res_InputWidget.value()
+        x_range = self._scanning_logic.image_x_range[1] - self._scanning_logic.image_x_range[0]
+        y_range = self._scanning_logic.image_y_range[1] - self._scanning_logic.image_y_range[0]
+        if self._mw.pixel_res_RadioButton.isChecked():
+            res_length = x_range / self._mw.x_res_InputWidget.value()
+            self._mw.x_res_length_InputWidget.setValue(res_length)
+        else:
+            res_pixel = np.around(x_range / self._mw.x_res_length_InputWidget.value()).astype(int)
+            self._mw.x_res_InputWidget.setValue(res_pixel)
+            # Correct the resolution displayed to match the integer number of pixels
+            self._mw.x_res_length_InputWidget.setValue(x_range / res_pixel)
+        # Update pixel and length for the y values
+        self._mw.y_res_InputWidget.setValue((y_range / x_range) * self._mw.x_res_InputWidget.value())
+        self._mw.y_res_length_InputWidget.setValue(self._mw.x_res_length_InputWidget.value())
+        self._scanning_logic.xy_resolution = self._mw.x_res_InputWidget.value()
 
     def change_z_resolution(self):
         """ Update the z resolution in the logic according to the GUI.
         """
+        z_range = self._scanning_logic.image_z_range[1] - self._scanning_logic.image_z_range[0]
+        if self._mw.pixel_res_RadioButton.isChecked():
+            res_length = z_range / self._mw.z_res_InputWidget.value()
+            self._mw.z_res_length_InputWidget.setValue(res_length)
+        else:
+            res_pixel = np.around(z_range / self._mw.z_res_length_InputWidget.value()).astype(int)
+            self._mw.z_res_InputWidget.setValue(res_pixel)
+            # Correct the resolution displayed to match the integer number of pixels
+            self._mw.z_res_length_InputWidget.setValue(z_range / res_pixel)
         self._scanning_logic.z_resolution = self._mw.z_res_InputWidget.value()
+
+    def update_res_input(self):
+        """ Update which input box is enabled according to the radio buttons.
+        """
+        using_pixels = self._mw.pixel_res_RadioButton.isChecked()
+        self._mw.x_res_InputWidget.setEnabled(using_pixels)
+        self._mw.z_res_InputWidget.setEnabled(using_pixels)
+        self._mw.x_res_length_InputWidget.setEnabled(not using_pixels)
+        self._mw.z_res_length_InputWidget.setEnabled(not using_pixels)
 
     def change_x_image_range(self):
         """ Adjust the image range for x in the logic. """
         self._scanning_logic.image_x_range = [
             self._mw.x_min_InputWidget.value(),
             self._mw.x_max_InputWidget.value()]
+        self.change_xy_resolution()
 
     def change_y_image_range(self):
         """ Adjust the image range for y in the logic.
@@ -1283,12 +1331,14 @@ class ConfocalGui(GUIBase):
         self._scanning_logic.image_y_range = [
             self._mw.y_min_InputWidget.value(),
             self._mw.y_max_InputWidget.value()]
+        self.change_xy_resolution()
 
     def change_z_image_range(self):
         """ Adjust the image range for z in the logic. """
         self._scanning_logic.image_z_range = [
             self._mw.z_min_InputWidget.value(),
             self._mw.z_max_InputWidget.value()]
+        self.change_xy_resolution()
 
     def update_tilt_correction(self):
         """ Update all tilt points from the scanner logic. """

--- a/gui/confocal/ui_confocalgui.ui
+++ b/gui/confocal/ui_confocalgui.ui
@@ -28,7 +28,7 @@
      <x>0</x>
      <y>0</y>
      <width>1261</width>
-     <height>21</height>
+     <height>27</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -403,42 +403,14 @@
    </attribute>
    <widget class="QWidget" name="dockWidgetContents_3">
     <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="0" colspan="2">
-      <widget class="QLabel" name="resolutionLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>125</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Resolution</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
+     <item row="0" column="3">
       <widget class="Line" name="line">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
       </widget>
      </item>
-     <item row="0" column="3" colspan="2">
+     <item row="0" column="4" colspan="2">
       <widget class="QLabel" name="scanrangeLabel">
        <property name="text">
         <string>Scan Range</string>
@@ -448,7 +420,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="5">
+     <item row="0" column="6">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -461,7 +433,7 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="xAxisLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -484,8 +456,8 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QSpinBox" name="xy_res_InputWidget">
+     <item row="2" column="1">
+      <widget class="QSpinBox" name="x_res_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -494,7 +466,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -508,7 +480,7 @@
         <bool>true</bool>
        </property>
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;XY-Resolution&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;X-Resolution in piexls&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -530,14 +502,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="2" column="3">
       <widget class="Line" name="line_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
       </widget>
      </item>
-     <item row="1" column="4">
+     <item row="2" column="5">
       <widget class="ScienDSpinBox" name="x_max_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -553,7 +525,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -589,7 +561,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="5">
+     <item row="2" column="6">
       <widget class="QSlider" name="x_SliderWidget">
        <property name="minimumSize">
         <size>
@@ -605,7 +577,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="6">
+     <item row="2" column="7">
       <widget class="ScienDSpinBox" name="x_current_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -660,7 +632,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="yAxisLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -680,30 +652,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>56</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="2" column="2">
+     <item row="3" column="3">
       <widget class="Line" name="line_3">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
       </widget>
      </item>
-     <item row="2" column="3">
+     <item row="3" column="4">
       <widget class="ScienDSpinBox" name="y_min_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -719,7 +675,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -755,7 +711,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="4">
+     <item row="3" column="5">
       <widget class="ScienDSpinBox" name="y_max_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -771,7 +727,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -807,7 +763,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="5">
+     <item row="3" column="6">
       <widget class="QSlider" name="y_SliderWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -841,7 +797,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="6">
+     <item row="3" column="7">
       <widget class="ScienDSpinBox" name="y_current_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -896,7 +852,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="zAxisLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -922,7 +878,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QSpinBox" name="z_res_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -932,7 +888,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -946,7 +902,7 @@
         <bool>true</bool>
        </property>
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Z-Resolution&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Z-Resolution in piexls&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -968,14 +924,14 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
+     <item row="4" column="3">
       <widget class="Line" name="line_4">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
       </widget>
      </item>
-     <item row="3" column="3">
+     <item row="4" column="4">
       <widget class="ScienDSpinBox" name="z_min_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -991,7 +947,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -1027,7 +983,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="4">
+     <item row="4" column="5">
       <widget class="ScienDSpinBox" name="z_max_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1043,7 +999,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -1079,7 +1035,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="5">
+     <item row="4" column="6">
       <widget class="QSlider" name="z_SliderWidget">
        <property name="minimumSize">
         <size>
@@ -1092,7 +1048,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="6">
+     <item row="4" column="7">
       <widget class="ScienDSpinBox" name="z_current_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1144,20 +1100,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="5">
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="3">
+     <item row="2" column="4">
       <widget class="ScienDSpinBox" name="x_min_InputWidget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1173,7 +1116,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>70</width>
          <height>16777215</height>
         </size>
        </property>
@@ -1209,6 +1152,268 @@
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QSpinBox" name="y_res_InputWidget">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>70</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="mouseTracking">
+        <bool>true</bool>
+       </property>
+       <property name="acceptDrops">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Y-Resolution in piexls&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="accelerated">
+        <bool>true</bool>
+       </property>
+       <property name="minimum">
+        <number>2</number>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="ScienDSpinBox" name="y_res_length_InputWidget">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>70</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="mouseTracking">
+        <bool>true</bool>
+       </property>
+       <property name="acceptDrops">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;XY-Resolution in length&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="accelerated">
+        <bool>true</bool>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="ScienDSpinBox" name="z_res_length_InputWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>70</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="mouseTracking">
+        <bool>true</bool>
+       </property>
+       <property name="acceptDrops">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Z-Resolution in length&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="accelerated">
+        <bool>true</bool>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="ScienDSpinBox" name="x_res_length_InputWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>70</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="mouseTracking">
+        <bool>true</bool>
+       </property>
+       <property name="acceptDrops">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;XY-Resolution in length&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="accelerated">
+        <bool>true</bool>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" colspan="2">
+      <widget class="QLabel" name="resolutionLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Resolution</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QRadioButton" name="pixel_res_RadioButton">
+       <property name="text">
+        <string>pixels</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QRadioButton" name="length_res_RadioButton">
+       <property name="text">
+        <string>length</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -2331,7 +2536,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>xy_res_InputWidget</tabstop>
+  <tabstop>x_res_InputWidget</tabstop>
   <tabstop>z_res_InputWidget</tabstop>
   <tabstop>x_min_InputWidget</tabstop>
   <tabstop>x_max_InputWidget</tabstop>


### PR DESCRIPTION
## Description
Added a new set of spin-boxes to set the confocal resolution directly in µm (or any kind of length scale used in the experiment). The changes are mostly in GUI appearance. The code automatically converts everything back in pixels so that the logic maintains the same functionality.

## Motivation and Context
It is often convenient, especially when zooming in and out, to maintain the same spatial resolution and let the computer calculates the correct number of pixels to achieve it.

## How Has This Been Tested?
Tested with the dummy module on a Linux machine.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
