### PR TITLE
User saving

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -262,7 +262,6 @@ logic:
         win_data_directory: 'C:/Data'   # DO NOT CHANGE THE DIRECTORY HERE! ONLY IN THE CUSTOM FILE!
         unix_data_directory: 'Data/'
         log_into_daily_directory: True
-        # save_into_default_directory: True
         save_pdf: True
         save_png: True
 

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -117,6 +117,7 @@ class ConfocalGui(GUIBase):
     optimizerlogic1 = Connector(interface='OptimizerLogic')
 
     # config options for gui
+    blocking_while_saving = ConfigOption('blocking_while_saving', False)
     fixed_aspect_ratio_xy = ConfigOption('fixed_aspect_ratio_xy', True)
     fixed_aspect_ratio_depth = ConfigOption('fixed_aspect_ratio_depth', True)
     image_x_padding = ConfigOption('image_x_padding', 0.02)
@@ -1633,7 +1634,7 @@ class ConfocalGui(GUIBase):
 
     def save_xy_scan_data(self):
         """ Run the save routine from the logic to save the xy confocal data."""
-        self._save_dialog.show()
+        # self._save_dialog.show()  # Pointless. The logic will show the dialog already, no matter if blocking or not.
 
         cb_range = self.get_xy_cb_range()
 
@@ -1644,7 +1645,7 @@ class ConfocalGui(GUIBase):
             high_centile = self._mw.xy_cb_high_percentile_DoubleSpinBox.value()
             pcile_range = [low_centile, high_centile]
 
-        self._scanning_logic.save_xy_data(colorscale_range=cb_range, percentile_range=pcile_range, block=False)
+        self._scanning_logic.save_xy_data(colorscale_range=cb_range, percentile_range=pcile_range, block=self.blocking_while_saving)
 
     def save_xy_scan_image(self):
         """ Save the image and according to that the data.
@@ -1657,7 +1658,7 @@ class ConfocalGui(GUIBase):
 
     def save_depth_scan_data(self):
         """ Run the save routine from the logic to save the xy confocal pic."""
-        self._save_dialog.show()
+        # self._save_dialog.show()  # Pointless. The logic will show the dialog already, no matter if blocking or not.
 
         cb_range = self.get_depth_cb_range()
 
@@ -1668,7 +1669,7 @@ class ConfocalGui(GUIBase):
             high_centile = self._mw.depth_cb_high_percentile_DoubleSpinBox.value()
             pcile_range = [low_centile, high_centile]
 
-        self._scanning_logic.save_depth_data(colorscale_range=cb_range, percentile_range=pcile_range, block=False)
+        self._scanning_logic.save_depth_data(colorscale_range=cb_range, percentile_range=pcile_range, block=self.blocking_while_saving)
 
     def save_depth_scan_image(self):
         """ Save the image and according to that the data.

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -992,8 +992,8 @@ class ConfocalLogic(GenericLogic):
         self.signal_xy_data_saved.emit()
         return
 
-
-    def save_depth_data(self, colorscale_range=None, percentile_range=None, save_raw_data=False):
+    @QtCore.Slot(object, object)
+    def _save_depth_data(self, colorscale_range=None, percentile_range=None, save_raw_data=False):
 
         """ Save the current confocal depth data to file.
 

--- a/logic/counter_logic.py
+++ b/logic/counter_logic.py
@@ -316,21 +316,13 @@ class CounterLogic(GenericLogic):
                 if userstr is not None:
                     # This is ugly, but it works for now.
                     # An empty txt file is saved only for checking the duplicated user input string.
-                    with open(os.path.join(filepath, userstr), 'ab') as file:
-                        np.savetxt(file, np.array([]))
+                    np.savetxt(os.path.join(filepath, userstr), np.array([]))
                     filename = userstr
                 else:
                     return
             else:
                 filepath = self._save_logic.get_path_for_module(module_name='Counter')
                 filename = None
-
-            # if save_figure:
-            #     fig = self.draw_figure(data=np.array(self._data_to_save))
-            # else:
-            #     fig = None
-            # self._save_logic.save_data(data, filepath=filepath, parameters=parameters,
-            #                            filelabel=filelabel, plotfig=fig, delimiter='\t')
 
             if save_figure:
                 fig = self.draw_figure(data=np.array(self._data_to_save))

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -135,10 +135,9 @@ class SaveLogic(GenericLogic):
     _win_data_dir = ConfigOption('win_data_directory', 'C:/Data/')
     _unix_data_dir = ConfigOption('unix_data_directory', 'Data')
     log_into_daily_directory = ConfigOption('log_into_daily_directory', False, missing='warn')
-    save_into_default_directory = ConfigOption('save_into_default_directory', False)
+    save_into_default_directory = ConfigOption('save_into_default_directory', True)
     save_pdf = ConfigOption('save_pdf', False)
     save_png = ConfigOption('save_png', True)
-
 
     # Matplotlib style definition for saving plots
     mpl_qd_style = {
@@ -416,8 +415,8 @@ class SaveLogic(GenericLogic):
         # determine proper unique filename to save if none has been passed
         if filename is None:
             filename = timestamp.strftime('%Y%m%d-%H%M-%S' + '_' + filelabel)
-        else:
-            filename = filename + '_' + filelabel
+        # else:
+        #     filename = filename + '_' + filelabel
 
         filename_raw = filename + '_raw.dat'
         filename_params = filename + '_params.dat'
@@ -513,6 +512,7 @@ class SaveLogic(GenericLogic):
                                     fmt=fmt, header=header, delimiter=delimiter, comments='#',
                                     append=False)
 
+        #--------------------------------------------------------------------------------------------
         # Save thumbnail figure of plot
         if plotfig is not None:
             # create Metadata
@@ -531,7 +531,7 @@ class SaveLogic(GenericLogic):
             
             if self.save_pdf:
                 # determine the PDF-Filename
-                fig_fname_vector = os.path.join(filepath, filename)[:-4] + '_fig.pdf'
+                fig_fname_vector = os.path.join(filepath, filename) + '_fig.pdf'
 
                 # Create the PdfPages object to which we will save the pages:
                 # The with statement makes sure that the PdfPages object is closed properly at
@@ -546,7 +546,7 @@ class SaveLogic(GenericLogic):
 
             if self.save_png:
                 # determine the PNG-Filename and save the plain PNG
-                fig_fname_image = os.path.join(filepath, filename)[:-4] + '_fig.png'
+                fig_fname_image = os.path.join(filepath, filename) + '_fig.png'
                 plotfig.savefig(fig_fname_image, bbox_inches='tight', pad_inches=0.05)
 
                 # Use Pillow (an fork for PIL) to attach metadata to the PNG
@@ -568,14 +568,15 @@ class SaveLogic(GenericLogic):
                 # save the picture again, this time including the metadata
                 png_image.save(fig_fname_image, "png", pnginfo=png_metadata)
 
-            # Determine the TIFF-Filename and save the plain TIFF
-            fig_tif = os.path.join(filepath, filename) + '.tiff'
-            # Save as TIFF
-            png_image.save(fig_tif)
+            # # Determine the TIFF-Filename and save the plain TIFF
+            # fig_tif = os.path.join(filepath, filename) + '.tiff'
+            # # Save as TIFF
+            # png_image.save(fig_tif)
 
             # close matplotlib figure
             plt.close(plotfig)
             self.log.debug('Time needed to save data: {0:.2f}s'.format(time.time()-start_time))
+            #----------------------------------------------------------------------------------
 
     def save_array_as_text(self, data, filename, filepath='', fmt='%.15e', header='',
                            delimiter='\t', comments='#', append=False):

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -557,29 +557,6 @@ class SaveLogic(GenericLogic):
                 metadata['CreationDate'] = metadata['CreationDate'].strftime('%Y%m%d-%H%M-%S')
                 metadata['ModDate'] = metadata['ModDate'].strftime('%Y%m%d-%H%M-%S')
 
-
-            # determine the PDF-Filename
-            fig_fname_vector = os.path.join(filepath, filename) + '.pdf'
-
-            # Create the PdfPages object to which we will save the pages:
-            # The with statement makes sure that the PdfPages object is closed properly at
-            # the end of the block, even if an Exception occurs.
-            with PdfPages(fig_fname_vector) as pdf:
-                pdf.savefig(plotfig, bbox_inches='tight', pad_inches=0.05)
-
-                # We can also set the file's metadata via the PdfPages object:
-                pdf_metadata = pdf.infodict()
-                for x in metadata:
-                    pdf_metadata[x] = metadata[x]
-
-            # determine the PNG-Filename and save the plain PNG
-            fig_fname_image = os.path.join(filepath, filename) + '.png'
-            plotfig.savefig(fig_fname_image, bbox_inches='tight', pad_inches=0.05)
-
-            # Use Pillow (an fork for PIL) to attach metadata to the PNG
-            png_image = Image.open(fig_fname_image)
-            png_metadata = PngImagePlugin.PngInfo()
-
                 for x in metadata:
                     # make sure every value of the metadata is a string
                     if not isinstance(metadata[x], str):


### PR DESCRIPTION
Saving dialog window.

## Description
When properly configured, saving confocal maps or time-traces will open up a pop-up dialog window asking the user to choose the file name to be used when saving. The default behaviour remains the automatically generated file name.

## Motivation and Context
The automatically generated file name and folder structure are not much user-friendly. Especially for users used to any other software in existence, which asks the user for such details. The behaviour can be switched on and off in the config file (under the save logic section: save_into_default_directory). The default behaviour remains the automatically-generated structure.

## How Has This Been Tested?
Using the default dummy, since it does not require any experimental instrument.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ x ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ x ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ x ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
